### PR TITLE
Fix page to show the header

### DIFF
--- a/_posts/2017-03-30-ideas.markdown
+++ b/_posts/2017-03-30-ideas.markdown
@@ -1,0 +1,9 @@
+---
+layout: post
+title:  "Contribution Ideas"
+date:   2017-03-30 12:03:51 -0200
+categories: idea
+highlight: true
+
+---
+Want to contribute to the project? Below you can find a list of existing contribution ideas and instructions on how to suggest your own. 

--- a/_posts/2017-03-30-mezuro-info.markdown
+++ b/_posts/2017-03-30-mezuro-info.markdown
@@ -1,0 +1,11 @@
+---
+layout: post
+title:  "Mezuro - A Free Software platform for code metrics"
+date:   2017-03-30 15:39:40 -0200
+categories: tutorial
+image: /img/logo-mezuro.png
+---
+
+Welcome to the Mezuro Project. We aim to build a web platform for anyone to analyze the quality of their software with ease. Read the latest developments below, learn more about the project by visiting any of the other pages available through the menu, check it out live at [mezuro.org](http://mezuro.org) or [github.com/mezuro](https://github.com/mezuro) browse the code at Github.
+
+If you're looking to contribute, we'll be glad to help you. We're candidates for the Google Summer of Code in 2016 - if you're interested check out our [ideas](/ideas) page.a

--- a/ideas.html
+++ b/ideas.html
@@ -4,18 +4,6 @@ title: Ideas
 permalink: /ideas/
 ---
 
-<div class="section-highlight section--center mdl-grid mdl-grid--no-spacing mdl-shadow--2dp">
-
-  <header class="section__play-btn mdl-cell mdl-cell--3-col-desktop mdl-cell--2-col-tablet mdl-cell--4-col-phone" style=""></header>
-
-  <div class="mdl-card mdl-cell mdl-cell--9-col-desktop mdl-cell--6-col-tablet mdl-cell--4-col-phone">
-    <div class="mdl-card__supporting-text">
-      <h4>Contribution Ideas</h4>
-      <p>Want to contribute to the project? Below you can find a list of existing contribution ideas and instructions on how to suggest your own.</p>
-    </div>
-  </div>
-</div>
-
 <div class="page-content">
   {%include posts.html category="idea"%}
 </div>

--- a/index.html
+++ b/index.html
@@ -1,26 +1,24 @@
 ---
 layout: default
 ---
+<div class="page-content">
+  <div class="section-highlight section--center mdl-grid mdl-grid--no-spacing mdl-shadow--2dp">
+    <header class="section__play-btn mdl-cell mdl-cell--3-col-desktop mdl-cell--2-col-tablet mdl-cell--4-col-phone" style=""></header>
 
-<div class="section-highlight section--center mdl-grid mdl-grid--no-spacing mdl-shadow--2dp">
-  <header class="section__play-btn mdl-cell mdl-cell--3-col-desktop mdl-cell--2-col-tablet mdl-cell--4-col-phone" style=""></header>
+    <div class="mdl-card mdl-cell mdl-cell--9-col-desktop mdl-cell--6-col-tablet mdl-cell--4-col-phone">
+      <div class="mdl-card__supporting-text">
+        <h3>Mezuro - A Free Software platform for code metrics</h3>
 
-  <div class="mdl-card mdl-cell mdl-cell--9-col-desktop mdl-cell--6-col-tablet mdl-cell--4-col-phone">
-    <div class="mdl-card__supporting-text">
-      <h3>Mezuro - A Free Software platform for code metrics</h3>
-
-      <p>Welcome to the Mezuro Project. We aim to build a web platform for anyone to analyze the quality of their software
-      with ease. Read the latest developments below, learn more about the project by visiting any of the other pages
-      available through the menu, check it out live at <a href="http://mezuro.org">mezuro.org</a> or
-      <a href="https://github.com/mezuro">browse the code at Github.</a>
-      </p>
-      <p>If you're looking to contribute, we'll be glad to help you. We're candidates for the Google Summer of Code in 2016 -
-      if you're interested check out our <a href="/ideas">ideas</a> page.
-      </p>
+        <p>Welcome to the Mezuro Project. We aim to build a web platform for anyone to analyze the quality of their software
+        with ease. Read the latest developments below, learn more about the project by visiting any of the other pages
+        available through the menu, check it out live at <a href="http://mezuro.org">mezuro.org</a> or
+        <a href="https://github.com/mezuro">browse the code at Github.</a>
+        </p>
+        <p>If you're looking to contribute, we'll be glad to help you. We're candidates for the Google Summer of Code in 2016 -
+        if you're interested check out our <a href="/ideas">ideas</a> page.
+        </p>
+      </div>
     </div>
   </div>
-</div>
-
-<div class="page-content">
   {%include posts-cards.html %}
 </div>

--- a/index.html
+++ b/index.html
@@ -1,24 +1,7 @@
 ---
 layout: default
 ---
+
 <div class="page-content">
-  <div class="section-highlight section--center mdl-grid mdl-grid--no-spacing mdl-shadow--2dp">
-    <header class="section__play-btn mdl-cell mdl-cell--3-col-desktop mdl-cell--2-col-tablet mdl-cell--4-col-phone" style=""></header>
-
-    <div class="mdl-card mdl-cell mdl-cell--9-col-desktop mdl-cell--6-col-tablet mdl-cell--4-col-phone">
-      <div class="mdl-card__supporting-text">
-        <h3>Mezuro - A Free Software platform for code metrics</h3>
-
-        <p>Welcome to the Mezuro Project. We aim to build a web platform for anyone to analyze the quality of their software
-        with ease. Read the latest developments below, learn more about the project by visiting any of the other pages
-        available through the menu, check it out live at <a href="http://mezuro.org">mezuro.org</a> or
-        <a href="https://github.com/mezuro">browse the code at Github.</a>
-        </p>
-        <p>If you're looking to contribute, we'll be glad to help you. We're candidates for the Google Summer of Code in 2016 -
-        if you're interested check out our <a href="/ideas">ideas</a> page.
-        </p>
-      </div>
-    </div>
-  </div>
   {%include posts-cards.html %}
 </div>


### PR DESCRIPTION
There were some hard code posts at index.html and ideas.html. We used the Jekyll post system to create those posts with markdown syntax and remove that hard code.

We didn't know the correct format of cards. So at index, the header now is a common card. It will need a new layout if more highlight is needed.

Another problem is in the idea page. The texts of idea and google summer of code are too small and it make the card too small what make the layout get a little strange.